### PR TITLE
doc(readme): add link to avante source repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # blink-cmp-avante
 
-Avante source for [blink.cmp](https://github.com/Saghen/blink.cmp)
+[Avante](https://github.com/yetone/avante.nvim) source for [blink.cmp](https://github.com/Saghen/blink.cmp)
 
 Use `@` to trigger the mention completion:
 


### PR DESCRIPTION
It seemed like this should be in the readme somewhere. Also might be good to add tags to the repo, like `avante`, `neovim`, `blink-cmp`, `code-completion`, or others that might help visibility. Thanks for your work!