### PR TITLE
fix: setting cmp item callback to `nil` removing original command callback

### DIFF
--- a/lua/blink-cmp-avante/default.lua
+++ b/lua/blink-cmp-avante/default.lua
@@ -31,7 +31,7 @@ local function default_mention_get_items()
 end
 
 local function default_command_get_items()
-    local items = require("avante.utils").get_commands()
+    local items = vim.deepcopy(require("avante.utils").get_commands())
     -- clear the callback
     for _, item in ipairs(items) do
         item.callback = nil


### PR DESCRIPTION
Setting cmp item callback to nil removing original command callback
This is leading to callback not found, when we try to execute it

![image](https://github.com/user-attachments/assets/dc894cda-2a9e-4f33-a49e-af972219fa4d)

This PR fixes that with `vim.deepcopy`