### PR TITLE
feat: add shortcut completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Use `/` to trigger the command completion:
 
 ![](./images/demo-avante-command.png)
 
+Use `#` to trigger the shortcut completion:
+
 ## Installation
 
 Add the plugin to your packer managers, and make sure it is loaded before `blink.cmp`.
@@ -59,7 +61,7 @@ Customize the `BlinkCmpKindAvante` to customize the highlight for kind icon, her
 vim.api.nvim_set_hl(0, 'BlinkCmpKindAvante', { default = false, fg = '#89b4fa' })
 ```
 
-### How to customize different icons for mention and command
+### How to customize different icons for mention, command and shortcut
 
 Firstly, you need to customize the `get_kind_name`, here is an example:
 
@@ -74,6 +76,11 @@ avante = {
         get_kind_name = function(_)
             return 'AvanteMention'
         end
+    },
+    shortcut = {
+        get_kind_name = function(_)
+            return 'AvanteShortcut'
+        end
     }
 }
 ```
@@ -82,8 +89,9 @@ Then, you should customize the `kind_icons`:
 
 ```lua
 kind_icons = {
-    AvanteCmd = '',
-    AvanteMention = '',
+    AvanteCmd = "",
+    AvanteMention = "",
+    AvanteShortcut = '',
 }
 ```
 
@@ -92,6 +100,7 @@ Maybe, you want to customize the highlight for icons:
 ```lua
 vim.api.nvim_set_hl(0, 'BlinkCmpKindAvanteCmd', { default = false, fg = '#89b4fa' })
 vim.api.nvim_set_hl(0, 'BlinkCmpKindAvanteMention', { default = false, fg = '#89b4fa' })
+vim.api.nvim_set_hl(0, 'BlinkCmpKindAvanteShortcut', { default = false, fg = '#89b4fa' })
 ```
 
 ## Version Introduction

--- a/lua/blink-cmp-avante/default.lua
+++ b/lua/blink-cmp-avante/default.lua
@@ -1,79 +1,107 @@
 local function default_enable()
-    return vim.bo.filetype == 'AvanteInput'
+	return vim.bo.filetype == "AvanteInput"
 end
 
 local function default_get_kind_name(_)
-    return 'Avante'
+	return "Avante"
 end
 
 local function default_mention_get_items()
-    local items = require('avante.utils').get_mentions()
-    local side_bar, _, _ = require('avante').get()
-    table.insert(items, {
-        description = "file",
-        command = "file",
-        details = "add files...",
-        callback = function() side_bar.file_selector:open() end,
-    })
-    table.insert(items, {
-        description = "quickfix",
-        command = "quickfix",
-        details = "add files in quickfix list to chat context",
-        callback = function() side_bar.file_selector:add_quickfix_files() end,
-    })
-    table.insert(items, {
-        description = "buffers",
-        command = "buffers",
-        details = "add open buffers to the chat context",
-        callback = function() side_bar.file_selector:add_buffer_files() end,
-    })
-    return items
+	local items = require("avante.utils").get_mentions()
+	local side_bar, _, _ = require("avante").get()
+	table.insert(items, {
+		description = "file",
+		command = "file",
+		details = "add files...",
+		callback = function()
+			side_bar.file_selector:open()
+		end,
+	})
+	table.insert(items, {
+		description = "quickfix",
+		command = "quickfix",
+		details = "add files in quickfix list to chat context",
+		callback = function()
+			side_bar.file_selector:add_quickfix_files()
+		end,
+	})
+	table.insert(items, {
+		description = "buffers",
+		command = "buffers",
+		details = "add open buffers to the chat context",
+		callback = function()
+			side_bar.file_selector:add_buffer_files()
+		end,
+	})
+	return items
 end
 
 local function default_command_get_items()
-    local items = vim.deepcopy(require("avante.utils").get_commands())
-    -- clear the callback
-    for _, item in ipairs(items) do
-        item.callback = nil
-    end
-    return items
+	local items = vim.deepcopy(require("avante.utils").get_commands())
+	-- clear the callback
+	for _, item in ipairs(items) do
+		item.callback = nil
+	end
+	return items
+end
+
+local function default_shortcut_get_items()
+	local items = vim.deepcopy(require("avante.utils").get_shortcuts())
+	-- clear the callback if it exists (shortcuts don't have callbacks by default)
+	for _, item in ipairs(items) do
+		item.callback = nil
+	end
+	return items
 end
 
 local function default_get_documentation(item)
-    return item.details
+	return item.details
 end
 
 local function default_mention_get_label(item)
-    return '@' .. item.command
+	return "@" .. item.command
 end
 
 local function default_command_get_label(item)
-    return '/' .. item.name
+	return "/" .. item.name
+end
+
+local function default_shortcut_get_label(item)
+	return "#" .. item.name
 end
 
 --- @type blink-cmp-avante.Options
 return {
-    kind_icons = {
-        Avante = '󰖷',
-    },
-    avante = {
-        command = {
-            enable = default_enable,
-            triggers = { '/' },
-            get_items = default_command_get_items,
-            get_label = default_command_get_label,
-            get_kind_name = default_get_kind_name,
-            get_insert_text = default_command_get_label,
-            get_documentation = default_get_documentation,
-        },
-        mention = {
-            enable = default_enable,
-            triggers = { '@' },
-            get_items = default_mention_get_items,
-            get_label = default_mention_get_label,
-            get_kind_name = default_get_kind_name,
-            get_insert_text = default_mention_get_label,
-            get_documentation = default_get_documentation,
-        },
-    }
+	kind_icons = {
+		Avante = "󰖷",
+	},
+	avante = {
+		command = {
+			enable = default_enable,
+			triggers = { "/" },
+			get_items = default_command_get_items,
+			get_label = default_command_get_label,
+			get_kind_name = default_get_kind_name,
+			get_insert_text = default_command_get_label,
+			get_documentation = default_get_documentation,
+		},
+		mention = {
+			enable = default_enable,
+			triggers = { "@" },
+			get_items = default_mention_get_items,
+			get_label = default_mention_get_label,
+			get_kind_name = default_get_kind_name,
+			get_insert_text = default_mention_get_label,
+			get_documentation = default_get_documentation,
+		},
+		shortcut = {
+			enable = default_enable,
+			triggers = { "#" },
+			get_items = default_shortcut_get_items,
+			get_label = default_shortcut_get_label,
+			get_kind_name = default_get_kind_name,
+			get_insert_text = default_shortcut_get_label,
+			get_documentation = default_get_documentation,
+		},
+	},
 }

--- a/lua/blink-cmp-avante/default.lua
+++ b/lua/blink-cmp-avante/default.lua
@@ -1,107 +1,89 @@
-local function default_enable()
-	return vim.bo.filetype == "AvanteInput"
-end
+local function default_enable() return vim.bo.filetype == 'AvanteInput' end
 
-local function default_get_kind_name(_)
-	return "Avante"
-end
+local function default_get_kind_name(_) return 'Avante' end
 
 local function default_mention_get_items()
-	local items = require("avante.utils").get_mentions()
-	local side_bar, _, _ = require("avante").get()
-	table.insert(items, {
-		description = "file",
-		command = "file",
-		details = "add files...",
-		callback = function()
-			side_bar.file_selector:open()
-		end,
-	})
-	table.insert(items, {
-		description = "quickfix",
-		command = "quickfix",
-		details = "add files in quickfix list to chat context",
-		callback = function()
-			side_bar.file_selector:add_quickfix_files()
-		end,
-	})
-	table.insert(items, {
-		description = "buffers",
-		command = "buffers",
-		details = "add open buffers to the chat context",
-		callback = function()
-			side_bar.file_selector:add_buffer_files()
-		end,
-	})
-	return items
+    local items = require('avante.utils').get_mentions()
+    local side_bar, _, _ = require('avante').get()
+    table.insert(items, {
+        description = 'file',
+        command = 'file',
+        details = 'add files...',
+        callback = function() side_bar.file_selector:open() end,
+    })
+    table.insert(items, {
+        description = 'quickfix',
+        command = 'quickfix',
+        details = 'add files in quickfix list to chat context',
+        callback = function() side_bar.file_selector:add_quickfix_files() end,
+    })
+    table.insert(items, {
+        description = 'buffers',
+        command = 'buffers',
+        details = 'add open buffers to the chat context',
+        callback = function() side_bar.file_selector:add_buffer_files() end,
+    })
+    return items
 end
 
 local function default_command_get_items()
-	local items = vim.deepcopy(require("avante.utils").get_commands())
-	-- clear the callback
-	for _, item in ipairs(items) do
-		item.callback = nil
-	end
-	return items
+    local items = vim.deepcopy(require('avante.utils').get_commands())
+    -- clear the callback
+    for _, item in ipairs(items) do
+        item.callback = nil
+    end
+    return items
 end
 
 local function default_shortcut_get_items()
-	local items = vim.deepcopy(require("avante.utils").get_shortcuts())
-	-- clear the callback if it exists (shortcuts don't have callbacks by default)
-	for _, item in ipairs(items) do
-		item.callback = nil
-	end
-	return items
+    local items = vim.deepcopy(require('avante.utils').get_shortcuts())
+    -- clear the callback if it exists (shortcuts don't have callbacks by default)
+    for _, item in ipairs(items) do
+        item.callback = nil
+    end
+    return items
 end
 
-local function default_get_documentation(item)
-	return item.details
-end
+local function default_get_documentation(item) return item.details end
 
-local function default_mention_get_label(item)
-	return "@" .. item.command
-end
+local function default_mention_get_label(item) return '@' .. item.command end
 
-local function default_command_get_label(item)
-	return "/" .. item.name
-end
+local function default_command_get_label(item) return '/' .. item.name end
 
-local function default_shortcut_get_label(item)
-	return "#" .. item.name
-end
+local function default_shortcut_get_label(item) return '#' .. item.name end
 
 --- @type blink-cmp-avante.Options
 return {
-	kind_icons = {
-		Avante = "󰖷",
-	},
-	avante = {
-		command = {
-			enable = default_enable,
-			triggers = { "/" },
-			get_items = default_command_get_items,
-			get_label = default_command_get_label,
-			get_kind_name = default_get_kind_name,
-			get_insert_text = default_command_get_label,
-			get_documentation = default_get_documentation,
-		},
-		mention = {
-			enable = default_enable,
-			triggers = { "@" },
-			get_items = default_mention_get_items,
-			get_label = default_mention_get_label,
-			get_kind_name = default_get_kind_name,
-			get_insert_text = default_mention_get_label,
-			get_documentation = default_get_documentation,
-		},
-		shortcut = {
-			enable = default_enable,
-			triggers = { "#" },
-			get_items = default_shortcut_get_items,
-			get_label = default_shortcut_get_label,
-			get_kind_name = default_get_kind_name,
-			get_insert_text = default_shortcut_get_label,
-			get_documentation = default_get_documentation,
-		},
-	},
+    kind_icons = {
+        Avante = '󰖷',
+    },
+    avante = {
+        command = {
+            enable = default_enable,
+            triggers = { '/' },
+            get_items = default_command_get_items,
+            get_label = default_command_get_label,
+            get_kind_name = default_get_kind_name,
+            get_insert_text = default_command_get_label,
+            get_documentation = default_get_documentation,
+        },
+        mention = {
+            enable = default_enable,
+            triggers = { '@' },
+            get_items = default_mention_get_items,
+            get_label = default_mention_get_label,
+            get_kind_name = default_get_kind_name,
+            get_insert_text = default_mention_get_label,
+            get_documentation = default_get_documentation,
+        },
+        shortcut = {
+            enable = default_enable,
+            triggers = { '#' },
+            get_items = default_shortcut_get_items,
+            get_label = default_shortcut_get_label,
+            get_kind_name = default_get_kind_name,
+            get_insert_text = default_shortcut_get_label,
+            get_documentation = default_get_documentation,
+        },
+    },
 }

--- a/lua/blink-cmp-avante/init.lua
+++ b/lua/blink-cmp-avante/init.lua
@@ -13,9 +13,7 @@ function AvanteSource.new(opts, _)
     local completion_item_kind = require('blink.cmp.types').CompletionItemKind
     local blink_kind_icons = require('blink.cmp.config').appearance.kind_icons
     for kind_name, icon in pairs(self.avante_source_config.kind_icons) do
-        if completion_item_kind[kind_name] then
-            goto continue
-        end
+        if completion_item_kind[kind_name] then goto continue end
         completion_item_kind[#completion_item_kind + 1] = kind_name
         completion_item_kind[kind_name] = #completion_item_kind
         blink_kind_icons[kind_name] = icon
@@ -43,9 +41,7 @@ function AvanteSource:get_enabled_features()
     --- @type blink-cmp-avante.AvanteOptions[]
     local features = {}
     for _, feature in pairs(vim.tbl_values(self.avante_source_config.avante)) do
-        if untils.get_option(feature.enable) then
-            table.insert(features, feature)
-        end
+        if untils.get_option(feature.enable) then table.insert(features, feature) end
     end
     return features
 end
@@ -56,8 +52,8 @@ end
 
 --- @param context blink.cmp.Context
 function AvanteSource:should_show_items(context, _)
-    return context.mode ~= 'cmdline' and
-        vim.tbl_contains(self:get_trigger_characters(), context.trigger.initial_character)
+    return context.mode ~= 'cmdline'
+        and vim.tbl_contains(self:get_trigger_characters(), context.trigger.initial_character)
 end
 
 --- @param context blink.cmp.Context
@@ -67,12 +63,12 @@ local function get_text_edit_range(context)
         -- This range make it possible to remove the trigger character
         start = {
             line = context.cursor[1] - 1,
-            character = context.cursor[2] - 1
+            character = context.cursor[2] - 1,
         },
         ['end'] = {
             line = context.cursor[1] - 1,
-            character = context.cursor[2]
-        }
+            character = context.cursor[2],
+        },
     }
 end
 
@@ -120,7 +116,7 @@ function AvanteSource:execute(_, item, callback, default_implementation)
         ---@diagnostic disable-next-line: undefined-field
         item.callback()
     else
-      default_implementation()
+        default_implementation()
     end
     callback()
 end


### PR DESCRIPTION
- Update README to reflect the addition of a new shortcut completion triggered by `#`
- Add new configuration options and examples for customizing shortcut icons and names in the README
- Introduce a new `default_shortcut_get_items` function to handle shortcut completions
- Add a new `default_shortcut_get_label` function to format shortcut labels
- Integrate shortcut functionality into the main configuration, including triggers, item retrieval, labeling, kind naming, insertion text, and documentation